### PR TITLE
Schmidt decomposition fixes

### DIFF
--- a/src/atmos_flux_inversion/linalg.py
+++ b/src/atmos_flux_inversion/linalg.py
@@ -221,6 +221,9 @@ def schmidt_decomposition(vector, dim1, dim2):
 
     big_lambdas = nonzero(lambdas)[0]
 
+    if not big_lambdas.any():
+        return lambdas[:1], vecs1.T[:1, :], vecs2[:1, :]
+
     return lambdas[big_lambdas], vecs1.T[big_lambdas, :], vecs2[big_lambdas, :]
 
 

--- a/src/atmos_flux_inversion/tests.py
+++ b/src/atmos_flux_inversion/tests.py
@@ -1676,6 +1676,8 @@ class TestUtilSchmidtDecomposition(unittest2.TestCase):
         vecs1 = np.asarray(vecs1)
         vecs2 = np.asarray(vecs2)
 
+        self.assertEqual(len(lambdas), 2)
+
         # This will not recover the original decomposition
         np_tst.assert_allclose(lambdas, (sqrt2o2, sqrt2o2))
         self.assertAlmostEqual(np.prod(lambdas), .5)
@@ -1722,6 +1724,14 @@ class TestUtilSchmidtDecomposition(unittest2.TestCase):
         lambdas, uvecs, vvecs = (
             atmos_flux_inversion.linalg.schmidt_decomposition(vec, 4, 5))
         self.assertNotIn(0, lambdas)
+
+    def test_zeros(self):
+        """Test that function gives sensible output on zero input."""
+        vec = np.zeros(20)
+        lambdas, uvecs, vvecs = (
+            atmos_flux_inversion.linalg.schmidt_decomposition(vec, 4, 5)
+        )
+        self.assertSequenceEqual(lambdas, [0])
 
 
 class TestUtilIsOdd(unittest2.TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Schmidt decomposition returned arrays with dimension zero when given input of zeros.
This fixes that case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves a bug in the implementation of `schmidt_decomposition`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test for zero input, tested that result has standard format and includes zero as a weight.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I give permission for my code to be distributed under the existing license
<!-- this may need to be okayed by your company's legal department if you did this on work time. -->
