### PR TITLE
Revert "Configure to use dense spatial correlations, not spectral."

### DIFF
--- a/paper2020/run_inversion_osse.py
+++ b/paper2020/run_inversion_osse.py
@@ -557,13 +557,13 @@ write_progress_message("Getting covariances")
 CORRELATION_LENGTH = 1000
 GRID_RESOLUTION = 27
 spatial_correlations = (
-    atmos_flux_inversion.correlations.make_matrix(
+    atmos_flux_inversion.correlations.HomogeneousIsotropicCorrelation.
+    from_function(
         atmos_flux_inversion.correlations.ExponentialCorrelation(
             CORRELATION_LENGTH / GRID_RESOLUTION),
         (len(TRUE_FLUXES_MATCHED.coords["dim_y"]),
          len(TRUE_FLUXES_MATCHED.coords["dim_x"])),
-    )
-)
+        is_cyclic=False))
 # spatial_correlation_remapper = np.full(
 #     # Grid points at full resolution, grid points at reduced resolution
 #     (spatial_correlations.shape[0], 1),
@@ -876,7 +876,7 @@ posterior_ds.to_netcdf(
     ("2010-07_monthly_inversion_{flux_interval:02d}h_027km_"
      "noise{ncorr_fun:s}{ncorr_len:d}km{ncorr_fun_time:s}{ncorr_len_time:d}d_"
      "icov{icorr_fun:s}{icorr_len:d}km{icorr_fun_time:s}{icorr_len_time:d}d_"
-     "output_dense_spatial_corr.nc4")
+     "output.nc4")
     .format(flux_interval=FLUX_INTERVAL, ncorr_fun=CORR_FUN,
             ncorr_len=CORR_LEN, icorr_len=CORRELATION_LENGTH, icorr_fun="exp",
             icorr_len_time=DAILY_FLUX_TIMESCALE, icorr_fun_time=DAILY_FLUX_FUN,
@@ -1068,7 +1068,7 @@ posterior_covariance_ds.to_netcdf(
     ("2010-07_monthly_inversion_{flux_interval:02d}h_027km_"
      "noise{ncorr_fun:s}{ncorr_len:d}km{ncorr_fun_time:s}{ncorr_len_time:d}d_"
      "icov{icorr_fun:s}{icorr_len:d}km{icorr_fun_time:s}{icorr_len_time:d}d_"
-     "{cov_res:d}km_{cov_tres:s}_covariance_output_dense_spatial_corr.nc4")
+     "{cov_res:d}km_{cov_tres:s}_covariance_output.nc4")
     .format(flux_interval=FLUX_INTERVAL, ncorr_fun=CORR_FUN,
             ncorr_len=CORR_LEN, icorr_len=CORRELATION_LENGTH, icorr_fun="exp",
             icorr_len_time=DAILY_FLUX_TIMESCALE, icorr_fun_time=DAILY_FLUX_FUN,


### PR DESCRIPTION
This reverts commit a609d5688fd83f9665e497afd60e0712fdb6ca00.

Change back to using spectral spatial correlations, as the spectral
ones didn't work that well.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apparently I underestimated the size of a dense covariance matrix.  This may have worked, eventually, but I think it stalled for the better part of a day trying to fill `B` before the system killed it.
*Much* slower than the spectral version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dense spatial code probably should not have been in the version that got merged into master.  This gets it back out again.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] I give permission for my code to be distributed under the existing license
<!-- this may need to be okayed by your company's legal department if you did this on work time. -->
