### PR TITLE
Remove trailing comma from .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -13,5 +13,5 @@
             "name": "DWesl"
         }
     ],
-    "access_right": "open",
+    "access_right": "open"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apparently in json, commas are separators, not terminators, so a trailing comma breaks parsers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Zenodo release creation didn't work.  This should fix that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```python
import json
with open(".zenodo.json", "r") as in_file:
    json.load(in_file)
```
no longer crashes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I give permission for my code to be distributed under the existing license
<!-- this may need to be okayed by your company's legal department if you did this on work time. -->
